### PR TITLE
feat: add account name to upvoter tag

### DIFF
--- a/src/upvoter/index.js
+++ b/src/upvoter/index.js
@@ -33,7 +33,7 @@ function getIsVoted(post, account) {
 }
 
 async function upvotePost(author, permlink, account, queue) {
-  const TAG = `[${author}/${permlink}]`;
+  const TAG = `[${account.username}: ${author}/${permlink}]`;
   debug(TAG, 'started upvoting');
 
   const blacklisted = await queue.isBlacklisted(author);


### PR DESCRIPTION
It's hard to distinguish messages coming from different accounts. It adds account.username to the tag, so we know which message comes from which account.