### PR TITLE
fix followersVests cache

### DIFF
--- a/src/upvoter/index.js
+++ b/src/upvoter/index.js
@@ -14,9 +14,13 @@ steem.api.setOptions({ url: STEEM_API });
 
 async function getVoteWeight(username, account, queue) {
   const cachedVests = await queue.getAccountFollowersVests(username);
-  const vests = cachedVests ? cachedVests : await getAccountFollowersVests(username);
 
-  await queue.setAccountFollowersVests(username, vests);
+  if (cachedVests) {
+    const vests = cachedVests;
+  } else {
+    const vests = await getAccountFollowersVests(username);
+    await queue.setAccountFollowersVests(username, vests);
+  }
 
   if (vests < account.minVests || vests > account.limitVests) return 0;
 


### PR DESCRIPTION
Fix https://github.com/busyorg/busy/issues/2192

Currently,`queue.setAccountFollowersVests(username, vests)` every time and this is why `VESTS_CACHE_SECONDS` never expire. Actually, since the introduction, it never been recalculated unless users don't write for 3 days.